### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,14 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.0] - 2026-02-03
 
-## [unreleased]
+### Bug Fixes
 
-## [0.1.0](https://github.com/tylerbutler/tiny-update-check/releases/tag/v0.1.0) - 2026-02-03
+- Correct template leftovers and enhance release pipeline (#2)
 
-### Added
-
-- initial implementation of tiny-update-check
-
-### Fixed
-
-- *(ci)* correct template leftovers and enhance release pipeline ([#2](https://github.com/tylerbutler/tiny-update-check/pull/2))
-
-### Security
-
-- pull latest bytes package with fix
 
 ### Features
 
-- Initial template release with tiered CI/CD configuration
+- Initial implementation of tiny-update-check
+


### PR DESCRIPTION



## 🤖 New release

* `tiny-update-check`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/tylerbutler/tiny-update-check/releases/tag/v0.1.0) - 2026-02-03

### Added

- initial implementation of tiny-update-check

### Fixed

- *(ci)* correct template leftovers and enhance release pipeline ([#2](https://github.com/tylerbutler/tiny-update-check/pull/2))

### Security

- pull latest bytes package with fix

### Features

- Initial template release with tiered CI/CD configuration
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).