### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,22 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [1.0.0](https://github.com/tylerbutler/tiny-update-check/compare/v0.1.0...v1.0.0) - 2026-02-06
+## [1.0.0] - 2026-02-06
 
 ### Bug Fixes
 
-- update Cargo.lock for 1.0.0 version
+- Fix release-plz workflow tag pushing and release creation
+
+- Centralize toolchain config and add binary size tracking (#14)
+
+- Install cargo-bloat instead of cargo-bloated
+
+- Update Cargo.lock for 1.0.0 version
+
 
 ### Features
 
-- add DO_NOT_TRACK environment variable support ([#17](https://github.com/tylerbutler/tiny-update-check/pull/17))
-
-### Refactor
-
-- simplify code and prepare for 1.0 release ([#13](https://github.com/tylerbutler/tiny-update-check/pull/13))
-- simplify code with idiomatic Rust patterns ([#10](https://github.com/tylerbutler/tiny-update-check/pull/10))
+- Add DO_NOT_TRACK environment variable support (#17)
 
 ## [0.1.0] - 2026-02-03
 

--- a/metrics/binary-size.txt
+++ b/metrics/binary-size.txt
@@ -3,3 +3,5 @@
 # Auto-populated by: just record-size
 2026-02-03 v0.1.0 native-tls 914240 893KB
 2026-02-03 v0.1.0 rustls 1975064 1.9MB
+2026-02-06 v1.0.0 native-tls 918336 897KB
+2026-02-06 v1.0.0 rustls 1975064 1.9MB

--- a/metrics/bloat-native-tls.txt
+++ b/metrics/bloat-native-tls.txt
@@ -1,13 +1,13 @@
 === native-tls ===
  File  .text     Size Crate
-12.5%  58.2% 320.5KiB std
+12.5%  58.5% 322.9KiB std
  4.9%  23.0% 126.9KiB ureq
  1.0%   4.6%  25.3KiB http
- 0.8%   3.5%  19.5KiB tiny_update_check
+ 0.7%   3.1%  17.4KiB tiny_update_check
  0.6%   2.9%  16.1KiB ureq_proto
  0.3%   1.4%   7.6KiB openssl
  0.2%   0.9%   5.0KiB bytes
- 0.2%   0.7%   3.9KiB semver
+ 0.2%   0.8%   4.6KiB semver
  0.1%   0.6%   3.6KiB httparse
  0.1%   0.6%   3.5KiB base64ct
  0.1%   0.6%   3.3KiB der
@@ -15,9 +15,9 @@
  0.1%   0.3%   1.6KiB openssl_probe
  0.1%   0.3%   1.5KiB [Unknown]
  0.0%   0.2%   1.3KiB once_cell
- 0.0%   0.2%   1.2KiB size_check
+ 0.0%   0.2%   1.3KiB size_check
  0.0%   0.1%     589B native_tls
  0.0%   0.0%     220B __rustc
-21.5% 100.0% 551.0KiB .text section size, the file size is 2.5MiB
+21.4% 100.0% 552.1KiB .text section size, the file size is 2.5MiB
 
 Note: numbers above are a result of guesswork. They are not 100% correct and never will be.

--- a/metrics/bloat-rustls.txt
+++ b/metrics/bloat-rustls.txt
@@ -1,20 +1,20 @@
 === rustls ===
  File  .text     Size Crate
- 7.3%  30.3% 407.1KiB std
+ 7.4%  30.4% 409.4KiB std
  5.9%  24.4% 328.9KiB rustls
  4.9%  20.3% 273.3KiB ring
  2.2%   9.1% 122.5KiB ureq
  1.3%   5.3%  71.5KiB [Unknown]
  0.8%   3.3%  44.3KiB webpki
  0.5%   1.9%  25.3KiB http
- 0.4%   1.4%  19.5KiB tiny_update_check
+ 0.3%   1.3%  17.3KiB tiny_update_check
  0.3%   1.2%  16.1KiB ureq_proto
  0.1%   0.4%   5.7KiB rustls_pki_types
  0.1%   0.4%   5.0KiB bytes
- 0.1%   0.3%   3.9KiB semver
+ 0.1%   0.3%   4.6KiB semver
  0.1%   0.3%   3.6KiB httparse
  0.0%   0.2%   2.3KiB base64
- 0.0%   0.1%   1.2KiB size_check_rustls
+ 0.0%   0.1%   1.3KiB size_check_rustls
  0.0%   0.0%     650B getrandom
  0.0%   0.0%     327B __rustc
  0.0%   0.0%      50B untrusted


### PR DESCRIPTION



## 🤖 New release

* `tiny-update-check`: 0.1.0 -> 1.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0](https://github.com/tylerbutler/tiny-update-check/compare/v0.1.0...v1.0.0) - 2026-02-06

### Bug Fixes

- update Cargo.lock for 1.0.0 version

### Features

- add DO_NOT_TRACK environment variable support ([#17](https://github.com/tylerbutler/tiny-update-check/pull/17))

### Refactor

- simplify code and prepare for 1.0 release ([#13](https://github.com/tylerbutler/tiny-update-check/pull/13))
- simplify code with idiomatic Rust patterns ([#10](https://github.com/tylerbutler/tiny-update-check/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).