### PR TITLE
ci: add auto-tag workflow for releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,28 @@
+name: Auto-tag release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  auto-tag:
+    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: tylerbutler/actions/changie-auto-tag@769fc7847a0abf82ee2f724df9b65426dfb159b5 # ratchet:tylerbutler/actions/changie-auto-tag@main
+        id: auto-tag
+        with:
+          create-release: true
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -2,8 +2,18 @@ name: Binary Size
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
+      - 'examples/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
Adds an `auto-tag.yml` workflow that triggers when a release PR (labeled `release`) is merged to main. Uses `tylerbutler/actions/changie-auto-tag` to:

1. Create a git tag from the latest changie version
2. Create a GitHub Release with the changelog notes

This was missing — `v1.1.0` and `v1.1.1` were released without tags or GitHub Releases.