### PR TITLE
ci: fix publish workflow startup_failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,13 @@ name: Publish
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 jobs:
-  test:
-    uses: ./.github/workflows/ci.yml
-
   publish:
-    needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
       - uses: tylerbutler/actions/setup-rust@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/setup-rust@main
 


### PR DESCRIPTION
Remove the reusable `ci.yml` call from the publish workflow's `test` job. Under `workflow_call`, `github.event_name` is `workflow_call` not `push`, which breaks the paths-filter change-detection logic in `ci.yml` and causes `startup_failure` before any jobs run. CI already validates code on the PR before tags are created, so re-running it at publish time is redundant.

Also adds `workflow_dispatch` to allow manually retriggering the publish without re-pushing a tag.

Fixes the failed v1.1.2 publish run (https://github.com/tylerbutler/tiny-update-check/actions/runs/24733838220).